### PR TITLE
[GSOC] fg compute block avg sse4

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,4 +1,5 @@
 bin_PROGRAMS = dectest
+
 dectest_SOURCES = dectest.c
-dectest_CPPFLAGS = -I$(srcdir)/../libovvc -I ../libovvc
+dectest_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/../libovvc -I ../libovvc
 dectest_LDADD = ../libovvc/libovvc.la

--- a/examples/bench_decorator.h
+++ b/examples/bench_decorator.h
@@ -1,0 +1,48 @@
+#ifndef BENCH_DECORATOR_H
+#define BENCH_DECORATOR_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "nvcl_structures.h"
+struct BenchWrapper
+{
+	size_t nb_fct_call;
+	size_t iter_per_fct;
+  	// Define function arguments here
+  	int (*func)(const OVSEI *sei, OVFrame **frame);
+};
+
+void bench_decorator(struct BenchWrapper bw, char* name, const OVSEI *sei, OVFrame **frame)
+{
+	volatile int dummy;
+	double total_avg_time = 0;
+
+	for (size_t i = 0; i < bw.nb_fct_call; ++i) {
+		double avg_time = 0;
+
+		for (size_t j = 0; j < bw.iter_per_fct; ++j) {
+			double t1 = clock();
+			volatile const int r = bw.func(sei, frame);
+			double t2 = clock();
+
+			dummy = r;
+			double dt = (t2 - t1) * 1000 / CLOCKS_PER_SEC; // millisecond
+
+			avg_time += dt;
+		}
+
+		avg_time /= (double)bw.iter_per_fct;
+		total_avg_time += avg_time;
+	}
+
+	total_avg_time /= (double)bw.nb_fct_call;
+	printf("%-20s: %f ms (average time / %lu calls of %lu iteration each)]\n",
+			name,
+			total_avg_time,
+			bw.nb_fct_call,
+			bw.iter_per_fct);
+}
+
+#endif

--- a/libovvc/Makefile.am
+++ b/libovvc/Makefile.am
@@ -1,5 +1,5 @@
 lib_LTLIBRARIES = libovvc.la
-libovvc_la_LDFLAGS = -version-info $(LIB_VERSION)
+libovvc_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LIB_VERSION)
 libovvc_la_LIBADD=
 
 pkgconfigdir = $(libdir)/pkgconfig


### PR DESCRIPTION
# Goal

- Add SSE4 version of fg-compute-block-avg
  - In the original version (no SSE), the function returns an `int16_t` but we accumulate on `  uint32_t blockAvg`
  - I decided to accumulate on `int16_t` to fetch more values (8) during `_mm_loadu_si128` call
  - Doing so forces us to perform a cast into `uint32_t` when calling `ov_clip_uintp2`
  - When performing the horizontal sum, we do `_mm_hadd_epi16` 3 times in a row. This puts the final sum in all elements of the register. We just need to copy the lower 32-bit integer using `_mm_cvtsi128_si32` in order to get the final result

# Results

![](https://i.imgur.com/IExK7kx.png)

# Steps to reproduce results

- Input Data: `RaceHorses_416x240_30_10_420_37_AI_FG.266`
- Benchmark function: At `ovdec.c:524` (at the `pp_process_frame()` call), replace by the following
```c
#include "../examples/bench_decorator.h"

// call the function pp_process_frame 1000 times with 100 iterations for each call.
struct BenchWrapper bw = { 1000, 100, &pp_process_frame };
bench_decorator(bw, "pp_process_frame", sei, frame_p);
// pp_process_frame(sei, frame_p);
```
- Run `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/libovvc/.libs perf record -o perf-opti.data ./examples/.libs/dectest -i fg/RaceHorses_416x240_30_10_420_37_AI_FG.266`
