### PR TITLE
[GSOC] fg simulate grain blk8x8 sse4

### DIFF
--- a/examples/bench_decorator.h
+++ b/examples/bench_decorator.h
@@ -1,0 +1,48 @@
+#ifndef BENCH_DECORATOR_H
+#define BENCH_DECORATOR_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "nvcl_structures.h"
+struct BenchWrapper
+{
+	size_t nb_fct_call;
+	size_t iter_per_fct;
+  	// Define function arguments here
+  	int (*func)(const OVSEI *sei, OVFrame **frame);
+};
+
+void bench_decorator(struct BenchWrapper bw, char* name, const OVSEI *sei, OVFrame **frame)
+{
+	volatile int dummy;
+	double total_avg_time = 0;
+
+	for (size_t i = 0; i < bw.nb_fct_call; ++i) {
+		double avg_time = 0;
+
+		for (size_t j = 0; j < bw.iter_per_fct; ++j) {
+			double t1 = clock();
+			volatile const int r = bw.func(sei, frame);
+			double t2 = clock();
+
+			dummy = r;
+			double dt = (t2 - t1) * 1000 / CLOCKS_PER_SEC; // millisecond
+
+			avg_time += dt;
+		}
+
+		avg_time /= (double)bw.iter_per_fct;
+		total_avg_time += avg_time;
+	}
+
+	total_avg_time /= (double)bw.nb_fct_call;
+	printf("%-20s: %f ms (average time / %lu calls of %lu iteration each)]\n",
+			name,
+			total_avg_time,
+			bw.nb_fct_call,
+			bw.iter_per_fct);
+}
+
+#endif


### PR DESCRIPTION
# Goal

- Add SSE4 version of `fg-simulate-grain-blk8x8`
  - When doing `_mm_loadu_si64` in the inner loop, we are fetching more value than we need (8 instead of 4)  because `int8_t fg_data_base`. Thus, we need to keep only the lower 32-bits which is done by calling `_mm_cvtepi8_epi32` and store the result in `fg_data_1_lo`.
  - After that, an element wise multiplication `_mm_mullo_epi32` is performed  followed by a division `_mm_srai_epi32`.

# Results

![](https://i.imgur.com/bd9KHpO.png)

# Steps to reproduce results

- Input Data: `RaceHorses_416x240_30_10_420_37_AI_FG.266`
- Benchmark function: At `ovdec.c:524` (at the `pp_process_frame()` call), replace by the following

```c
#include "../examples/bench_decorator.h"

// call the function pp_process_frame 1000 times with 100 iterations for each call.
struct BenchWrapper bw = { 1000, 100, &pp_process_frame };
bench_decorator(bw, "pp_process_frame", sei, frame_p);
// pp_process_frame(sei, frame_p);
```
- Run `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/libovvc/.libs perf record -o perf-opti.data ./examples/.libs/dectest -i fg/RaceHorses_416x240_30_10_420_37_AI_FG.266`